### PR TITLE
Bmcclure/better prom security

### DIFF
--- a/ImageRegistry/BuildTools/setup.certgetter.ps1
+++ b/ImageRegistry/BuildTools/setup.certgetter.ps1
@@ -1,0 +1,6 @@
+param(
+	$config
+	,$domain
+	)
+$config.Records | Select hosts,name,uid,gid,signingProfile
+$out | ConvertTo-Json -depth 5 | set-content $PSScriptRoot\test.json

--- a/ImageRegistry/Makefile
+++ b/ImageRegistry/Makefile
@@ -8,7 +8,7 @@ endif
 CORE_SERVICES := dns certgetter ca ingress
 BACKUP := registry_backup
 REGISTRY := registry registryui registry_mirror
-MONITORING := grafana prometheus nagios nagios_mysql prometheus_blackbox_exporter
+MONITORING := grafana prometheus nagios nagios_mysql prometheusblackbox
 ELASTIC := es01 es02 es03 kib01 logstash docker_logbeat
 PROXY := squidproxy squidmetrics
 MISC := youtube_dl scratch diagrams.net vscode calibre

--- a/ImageRegistry/docker-compose.monitoring.yml
+++ b/ImageRegistry/docker-compose.monitoring.yml
@@ -34,7 +34,9 @@ services:
      - ./mountPoints/prometheus/ca/dhha_ca.crt:/mnt/ca/dhha_ca.crt
     restart: ${RESTART_POLICY}
   prometheus_blackbox_exporter:
-    image: prom/blackbox-exporter:master
+    build: 
+        context: ./src/prometheus_blackbox_exporter
+        dockerfile: Dockerfile
     ports:
       - 9115:9115
     volumes:

--- a/ImageRegistry/docker-compose.monitoring.yml
+++ b/ImageRegistry/docker-compose.monitoring.yml
@@ -11,8 +11,6 @@ services:
     restart: ${RESTART_POLICY}
   grafana:
     image: grafana/grafana:7.1.5
-    ports:
-      - '3000:3000'
     env_file: grafana.env
     volumes:
       - grafana_data:/var/lib/grafana
@@ -26,19 +24,17 @@ services:
   prometheus:
     depends_on:
       - grafana
-    ports:
-      - '9090:9090'
-    image: prom/prometheus
+    build:
+        context: ./src/prometheus
+        dockerfile: Dockerfile
     volumes:
      - ./mountPoints/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
      - ./mountPoints/prometheus/ca/dhha_ca.crt:/mnt/ca/dhha_ca.crt
     restart: ${RESTART_POLICY}
-  prometheus_blackbox_exporter:
+  prometheusblackbox:
     build: 
-        context: ./src/prometheus_blackbox_exporter
+        context: ./src/prometheusblackbox
         dockerfile: Dockerfile
-    ports:
-      - 9115:9115
     volumes:
       - ./mountPoints/prometheus/blackbox.yml:/config/blackbox.yml
     command: "--config.file=/config/blackbox.yml"

--- a/ImageRegistry/docker-compose.yml
+++ b/ImageRegistry/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - diagrams_certs:/mnt/diagrams_certs
       - nagios_certs:/mnt/nagios_certs
       - prometheus_certs:/mnt/prometheus_certs
+      - prometheusblackbox_certs:/mnt/prometheusblackbox_certs
       - vscode_certs:/mnt/vscode_certs
       - calibre_certs:/mnt/calibre_certs
       - mineos_certs:/mnt/mineos_certs
@@ -82,6 +83,7 @@ services:
       - diagrams_certs:/etc/nginx/conf.d/diagrams
       - nagios_certs:/etc/nginx/conf.d/nagios
       - prometheus_certs:/etc/nginx/conf.d/prometheus
+      - prometheusblackbox_certs:/etc/nginx/conf.d/prometheusblackbox
       - registryui_certs:/etc/nginx/conf.d/registryui
       - registry_certs:/etc/nginx/conf.d/registry
       - vscode_certs:/etc/nginx/conf.d/vscode
@@ -123,6 +125,7 @@ volumes:
   diagrams_certs:
   nagios_certs:
   prometheus_certs:
+  prometheusblackbox_certs:
   vscode_certs:
   calibre_certs:
   mineos_certs:

--- a/ImageRegistry/docker-compose.yml
+++ b/ImageRegistry/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.5'
 services:
   ca:
     image: cfssl/cfssl
-    hostname: cfssl
+    hostname: ca
     domainname: cfssl
     restart: ${RESTART_POLICY}
     container_name: ca
@@ -31,7 +31,7 @@ services:
     volumes:
       - registry_certs:/mnt/registry_certs
       - grafana_certs:/mnt/grafana_certs
-      - ca_reverseproxy_certs:/mnt/ca_reverseproxy_certs
+      - ca_certs:/mnt/ca_certs
       - registryui_certs:/mnt/registryui_certs
       - squid_certs:/mnt/squid_certs
       - ldap_certs:/mnt/ldap_certs
@@ -44,6 +44,7 @@ services:
       - vscode_certs:/mnt/vscode_certs
       - calibre_certs:/mnt/calibre_certs
       - mineos_certs:/mnt/mineos_certs
+      - scratch_certs:/mnt/scratch_certs
     # Tried real hard to run this script with parameters, specifically the array of PSObjects. I could shell in and run the command below just fine, but could not get it in a place for the entrypoint
     # pwsh -command "& /work/New-CFSSL_Certificate.ps1 -certRequests ([PSCustomObject]@{name = 'registry'; hosts = @('ImageRegistry','localhost','127.0.0.1')},[PSCustomObject]@{name = 'grafana'; hosts = @('grafana','localhost','127.0.0.1')})"
     entrypoint: ["pwsh", "/work/New-CFSSL_Certificate.ps1"]
@@ -65,14 +66,14 @@ services:
     env_file: ca.env
     restart: ${RESTART_POLICY}
   ingress:
-    image: nginx
+    image: nginx:1.19-alpine
     ports:
       - 80:80
       - 443:443
     volumes:
       - ./mountPoints/ingress/basicAuth:/etc/nginx/basicAuth
       - ./mountPoints/ingress/nginx.conf:/etc/nginx/nginx.conf
-      - ca_reverseproxy_certs:/etc/nginx/conf.d/ca
+      - ca_certs:/etc/nginx/conf.d/ca
       - grafana_certs:/etc/nginx/conf.d/grafana
       - ldap_certs:/etc/nginx/conf.d/ldap
       - nextcloud_certs:/etc/nginx/conf.d/nextcloud
@@ -86,6 +87,7 @@ services:
       - vscode_certs:/etc/nginx/conf.d/vscode
       - calibre_certs:/etc/nginx/conf.d/calibre
       - mineos_certs:/etc/nginx/conf.d/mineos
+      - scratch_certs:/etc/nginx/conf.d/scratch
     restart: ${RESTART_POLICY}
   myvault:
       image: vault
@@ -111,7 +113,7 @@ volumes:
   squid_cache:
   squid_log:
   squid_certs:
-  ca_reverseproxy_certs:
+  ca_certs:
   registryui_certs:
   ldap_certs:
   dhcp_leases:
@@ -124,3 +126,4 @@ volumes:
   vscode_certs:
   calibre_certs:
   mineos_certs:
+  scratch_certs:

--- a/ImageRegistry/mountPoints/prometheus/blackbox.yml
+++ b/ImageRegistry/mountPoints/prometheus/blackbox.yml
@@ -1,6 +1,8 @@
 modules:
   http_2xx:
     prober: http
+    http:
+      preferred_ip_protocol: ip4
   http_post_2xx:
     prober: http
     http:

--- a/ImageRegistry/mountPoints/prometheus/prometheus.yml
+++ b/ImageRegistry/mountPoints/prometheus/prometheus.yml
@@ -31,9 +31,8 @@
         module: [http_2xx]  # Look for a HTTP 200 response.
       static_configs:
         - targets:
-          - http://prometheus.example.com:9115
+          - https://prometheusblackbox.example.com
           - https://www.google.com
-          - https://cogitodocumentation.hosp.dhha.org
           - https://prometheus.example.com
           - https://elastic.example.com
           - https://ca.example.com
@@ -43,4 +42,4 @@
         - source_labels: [__param_target]
           target_label: instance
         - target_label: __address__
-          replacement: prometheus.example.com:9115  # The blackbox exporter's real hostname:port.
+          replacement: prometheusblackbox.example.com  # The blackbox exporter's real hostname:port.

--- a/ImageRegistry/src/ca/New-CFSSL_Certificate.ps1
+++ b/ImageRegistry/src/ca/New-CFSSL_Certificate.ps1
@@ -16,7 +16,7 @@ param(
 		,[PSCustomObject]@{name = 'calibre'; hosts = @('calibre');}
 		,[PSCustomObject]@{name = 'mineos'; hosts = @('mineos');}
 		,[PSCustomObject]@{name = 'scratch'; hosts = @('scratch');}
-		,[PSCustomObject]@{name = 'promblackbox'; hosts = @('promblackbox');}
+		,[PSCustomObject]@{name = 'prometheusblackbox'; hosts = @('prometheusblackbox');}
 	),
 	$Country = "US",
 	$State = "Colorado",

--- a/ImageRegistry/src/ca/New-CFSSL_Certificate.ps1
+++ b/ImageRegistry/src/ca/New-CFSSL_Certificate.ps1
@@ -2,10 +2,10 @@ param(
 	$dev_bindings = $true,
 	$certRequests = @(
 		[PSCustomObject]@{name = 'registry'; hosts = @('ImageRegistry')}
-		,[PSCustomObject]@{name = 'grafana'; hosts = @('registry','proxy')}
+		,[PSCustomObject]@{name = 'grafana'; hosts = @('grafana')}
 		,[PSCustomObject]@{name = 'squid'; hosts = @('proxy'); uid = '200'; gid = '200'; signingProfile = "any"}
 		,[PSCustomObject]@{name = 'registryui'; hosts = @('ImageRegistry','registry');}
-		,[PSCustomObject]@{name = 'ca_reverseproxy'; hosts = @('ca');}
+		,[PSCustomObject]@{name = 'ca'; hosts = @('ca');}
 		,[PSCustomObject]@{name = 'nextcloud'; hosts = @('nc');}
 		,[PSCustomObject]@{name = 'elastic'; hosts = @('elastic');}
 		,[PSCustomObject]@{name = 'kibana'; hosts = @('kibana');}
@@ -15,6 +15,8 @@ param(
 		,[PSCustomObject]@{name = 'vscode'; hosts = @('vscode');}
 		,[PSCustomObject]@{name = 'calibre'; hosts = @('calibre');}
 		,[PSCustomObject]@{name = 'mineos'; hosts = @('mineos');}
+		,[PSCustomObject]@{name = 'scratch'; hosts = @('scratch');}
+		,[PSCustomObject]@{name = 'promblackbox'; hosts = @('promblackbox');}
 	),
 	$Country = "US",
 	$State = "Colorado",
@@ -126,7 +128,9 @@ foreach ($request in $certRequests){
 	if (-not [string]::IsNullOrEmpty($request.uid) -and -not [string]::IsNullOrEmpty($request.gid)){
 		Write-Host "Setting the UID:GID ownership"
 		chown $($request.uid):$($request.gid) $certOutPath/$($request.name)_certs/cert.crt
+		chmod 444 $certOutPath/$($request.name)_certs/cert.crt
 		chown $($request.uid):$($request.gid) $certOutPath/$($request.name)_certs/cert.key
+		chmod 444 $certOutPath/$($request.name)_certs/cert.key
 	}
 }
 tail -f /dev/null

--- a/ImageRegistry/src/prometheus/Dockerfile
+++ b/ImageRegistry/src/prometheus/Dockerfile
@@ -1,5 +1,7 @@
-FROM prom/prometheus
-COPY prometheus.yml /etc/prometheus/prometheus.yml
+FROM prom/prometheus:v2.26.0
+USER root
+COPY ca-bundle.crt /tmp/ca-bundle.crt
 
-HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=5 \ 
-    CMD wget --spider http://localhost:9090 || exit 1
+RUN cat /tmp/ca-bundle.crt >> /etc/ssl/certs/ca-certificates.crt
+
+USER nobody

--- a/ImageRegistry/src/prometheus_blackbox_exporter/Dockerfile
+++ b/ImageRegistry/src/prometheus_blackbox_exporter/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/blackbox-exporter:master
+COPY ca-bundle.crt /tmp/ca-bundle.crt
+
+RUN cat /tmp/ca-bundle.crt >> /etc/ssl/certs/ca-certificates.crt

--- a/ImageRegistry/src/prometheusblackbox/Dockerfile
+++ b/ImageRegistry/src/prometheusblackbox/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/blackbox-exporter:master
+COPY ca-bundle.crt /tmp/ca-bundle.crt
+
+RUN cat /tmp/ca-bundle.crt >> /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Bundle our CA with the prometheus and prometheus blackbox images in order to allow scrapping https endpoints that are using our self signed CA
Removes the ability to access grafana and prometheus directly/bypassing the ingress