### PR TITLE
Makefile - Fix elastic services to match the ones that are currently …

### DIFF
--- a/ImageRegistry/BuildTools/setup.ingress.ps1
+++ b/ImageRegistry/BuildTools/setup.ingress.ps1
@@ -49,16 +49,20 @@ foreach($record in $config.Records){
 	if([bool]($record.PSobject.Properties.name -match "upstreamScheme")){
 		$upstreamScheme = $record.upstreamScheme
 	}
+	$upstreamService = $record.Name
+	if([bool]($record.PSobject.Properties.name -match "upstreamService")){
+		$upstreamService = $record.upstreamService
+	}
 
 	$locations += "location / {
 		proxy_set_header Host `$host;
 		proxy_set_header X-Real-IP `$remote_addr;
 		proxy_set_header X-Forwarded-For `$proxy_add_x_forwarded_for;
 		proxy_set_header X-Forwarded-Proto `$scheme;
-		 set `$upstream $($upstreamScheme)://$($record.Name):$($record.port);
+		 set `$upstream $($upstreamScheme)://$($upstreamService):$($record.port);
 		 proxy_pass `$upstream;
 
-		 proxy_redirect $($upstreamScheme)://$($record.Name):$($record.port) https://$($record.Name).$domain;
+		 proxy_redirect $($upstreamScheme)://$($upstreamService):$($record.port) https://$($record.Name).$domain;
 	}"
 
 	if( [bool]($record.PSobject.Properties.name -match "ingressMappings")){

--- a/ImageRegistry/Configure.ps1
+++ b/ImageRegistry/Configure.ps1
@@ -268,4 +268,4 @@ $promConfig |replaceWith -find ".example.com" -replace ".$domain" `
 # Create Ingress
 $ingress = .\BuildTools\setup.ingress.ps1 -config $config -domain $domain
 Set-Content -Path $mountpointRoot/ingress/nginx.conf -Value $ingress
-Invoke-UnixLineEndings -directory $PSScriptRoot -excludeExtensions @("mdb","MYI","MYD")
+Invoke-UnixLineEndings -directory $PSScriptRoot -excludeExtensions @("mdb","MYI","MYD") -excludeFilter @("**\mointPoints\db*")

--- a/ImageRegistry/Makefile
+++ b/ImageRegistry/Makefile
@@ -9,7 +9,7 @@ CORE_SERVICES := dns certgetter ca ingress ingress_prom_exporter vault
 BACKUP := registry_backup
 REGISTRY := registry registryui registry_mirror
 MONITORING := grafana prometheus nagios nagios_mysql prometheusblackbox
-ELASTIC := es01 es02 es03 kib01 logstash docker_logbeat
+ELASTIC := es01 es02 es03 kib01 logstash
 PROXY := squidproxy squidmetrics
 MISC := youtube_dl scratch diagrams.net vscode calibre
 NEXTCLOUD := app db
@@ -51,7 +51,7 @@ registry: core
 core:
 	@docker-compose ${CORE_SERVICES_FILES} up -d --build ${CORE_SERVICES}
 elastic:
-	@docker-compose ${ELASTIC_SERVICES_FILES} up -d --build ${ELASTIC}
+	@docker-compose ${COMPOSE_ELASTIC_FILES} up -d --build ${ELASTIC}
 misc:
 	@docker-compose ${COMPOSE_MISC_FILES} up -d --build ${MISC_SERVICES}
 

--- a/ImageRegistry/config/config.example
+++ b/ImageRegistry/config/config.example
@@ -1,0 +1,31 @@
+{
+    "domain":"example.com",
+    "forward":[".","YourDNSForwarder","BackupDNSForwaderLike: 8.8.8.8"],
+	"DNS":{
+		"MNAME":"dns.","RNAME":"brandon.mcclure","SERIAL":"2015082541","REFRESH":"7200","RETRY":"3600","EXPIRE":"1209600","TTL":"3600"
+	},
+    "Records":[
+        {"Name":"dns","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost"},
+		{"Name":"ldap","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost"},
+        {"Name":"dhcp","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost"},
+        {"Name":"ca","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"8888"},
+		{"Name":"proxy","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost"},
+        {"Name":"registry","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"5000","Authentication":"basic"},
+		{"Name":"registryui","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"5000"},
+        {"Name":"gateway","ZoneClass":"IN","RecordType":"A","IpAddress":"192.168.0.1"},
+        {"Name":"grafana","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"3000","upstreamScheme":"https"},
+		{"Name":"prometheus","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"9090"},
+		{"Name":"prometheusblackbox","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"9090"},
+		{"Name":"elastic","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"9200","upstreamService":"es01"},
+		{"Name":"kibana","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"5601","upstreamService":"kib01"},
+        {"Name":"flatcarMirror","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost"},
+		{"Name":"nagios","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"4000"},
+		{"Name":"vault","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"8200"},
+		{"Name":"ingress","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"443","ingressMappings":[{"port":9113,"endpoint":"/metrics","ToService":"ingress_prom_exporter"}]},
+		{"Name":"nextcloud","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"3040"},
+		{"Name":"scratch","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7125"},
+		{"Name":"diagrams","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7124"},
+		{"Name":"vscode","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7126"},
+		{"Name":"calibre","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7123"}
+    ]
+}

--- a/ImageRegistry/docker-compose.elastic.yml
+++ b/ImageRegistry/docker-compose.elastic.yml
@@ -17,6 +17,7 @@ services:
       - data01:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
+    restart: ${RESTART_POLICY}
   es02:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0
     container_name: es02
@@ -33,6 +34,7 @@ services:
         hard: -1
     volumes:
       - data02:/usr/share/elasticsearch/data
+    restart: ${RESTART_POLICY}
   es03:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0
     container_name: es03
@@ -49,6 +51,7 @@ services:
         hard: -1
     volumes:
       - data03:/usr/share/elasticsearch/data
+    restart: ${RESTART_POLICY}
   kib01:
     image: docker.elastic.co/kibana/kibana:7.12.0
     container_name: kib01
@@ -57,29 +60,14 @@ services:
     environment:
       ELASTICSEARCH_URL: http://es01:9200
       ELASTICSEARCH_HOSTS: '["http://es01:9200","http://es02:9200","http://es03:9200"]'
+    restart: ${RESTART_POLICY}
   logstash:
     image: docker.elastic.co/logstash/logstash:7.12.0
     ports:
     - 12345:12345
     environment:
       TCP_PORT: 12345
-  metricbeat:
-    image: docker.elastic.co/beats/metricbeat:7.12.0
-    hostname: "es01-metricbeat"
-    user: root
-    networks:
-      - elastic
-    configs:
-      - source: mb_config
-        target: ./mountPoints/metricbeat/metricbeat.yml
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - metricbeat:/usr/share/metricbeat/data
-    env_file: elastic.env
-    # disable strict permission checks
-    command: ["--strict.perms=false", "-system.hostfs=/hostfs"]
-    deploy:
-      mode: global
+    restart: ${RESTART_POLICY}
 
 volumes:
   data01:

--- a/ImageRegistry/docker-compose.yml
+++ b/ImageRegistry/docker-compose.yml
@@ -104,8 +104,6 @@ services:
   vault:
       image: vault
       container_name: vault
-      ports:
-        - "127.0.0.1:8200:8200"
       volumes:
         - ./mountPoints/vault/file:/vault/file:rw
         - ./mountPoints/vault/config:/vault/config:rw

--- a/ImageRegistry/mountPoints/vault/config/vault.json
+++ b/ImageRegistry/mountPoints/vault/config/vault.json
@@ -1,4 +1,5 @@
 {
+	"ui":true,
 	"listener": 
 	  {
 		"tcp":


### PR DESCRIPTION
…in the docker-compose file/are working good.

Configure.ps1 - Allow me to exclude/filter out whole directories that we do not want to update the line endings to LF
setup.ingress.ps1 - the config file can take a upstreamService property and the setup script will use that service name when building the nginx.conf proxy definition. I needed this for the elastic cluster. The services are named es01,02,03, but I want to access it from elastic.mcd.com
config.example - an example config file. Rename it to config.json
vault - turn on the UI and only allow access through the ingress controller.