### PR TITLE
Generate a config file for homer for all the services in the config.j…

### DIFF
--- a/ImageRegistry/BuildTools/setup.homer.ps1
+++ b/ImageRegistry/BuildTools/setup.homer.ps1
@@ -1,0 +1,34 @@
+param($config)
+
+Import-Module powershell-yaml
+
+$services = @()
+
+foreach ($service in $config.Records){
+	$serviceObj = New-Object PSObject -Property @{
+		name=$service.Name
+		logo="assets/tools/sample.png"
+		subtitle=$service.Name
+		tag="app"
+		url="https://$($service.name).$($config.domain)"
+	}
+	$services += $serviceObj
+}
+
+$servicesWhole = New-Object PSObject -Property @{
+	items=$services
+}
+
+$configObj = new-object PSObject -Property @{
+	title="Brandon's Dashboard"
+	subtitle="Homer"
+	logo= "logo.png"
+	header="true"
+	footer='<p>Created with <span class="has-text-danger">❤️</span> with <a href="https://bulma.io/">bulma</a>, <a href="https://vuejs.org/">vuejs</a> & <a href="https://fontawesome.com/">font awesome</a> // Fork me on <a href="https://github.com/bastienwirtz/homer"><i class="fab fa-github-alt"></i></a></p>'
+	theme="default"
+	services=$servicesWhole
+
+}
+
+$outputPath = "$(Split-Path $PSScriptRoot -Parent)\mountPoints\homer\assets\config.yml"
+ ConvertTo-Yaml -data $configObj | Set-Content $outputPath -Force

--- a/ImageRegistry/Configure.ps1
+++ b/ImageRegistry/Configure.ps1
@@ -15,6 +15,7 @@ $REGISTRY_DELETE_ENABLE = $True
 ,[string] $VSCode_TZ = 'Americas\Denver'
 ,$ldapOrg = ""
 ,[securestring]$LDAPAdminPassword = $null
+,[switch]$GenerateHomerConfig
 )
 
 Import-Module powershell-yaml,FC_Log,FC_Core -force -ErrorAction Stop
@@ -268,4 +269,10 @@ $promConfig |replaceWith -find ".example.com" -replace ".$domain" `
 # Create Ingress
 $ingress = .\BuildTools\setup.ingress.ps1 -config $config -domain $domain
 Set-Content -Path $mountpointRoot/ingress/nginx.conf -Value $ingress
-Invoke-UnixLineEndings -directory $PSScriptRoot -excludeExtensions @("mdb","MYI","MYD") -excludeFilter @("**\mointPoints\db*")
+
+# Create homer dashboard config
+if($GenerateHomerConfig){
+	.\BuildTools\setup.homer.ps1 -config $config
+}
+
+Invoke-UnixLineEndings -directory $PSScriptRoot -excludeExtensions @("mdb","MYI","MYD") -excludeFilter @("**\mointPoints\db*","**\mointPoints\homer*")

--- a/ImageRegistry/Makefile
+++ b/ImageRegistry/Makefile
@@ -8,7 +8,7 @@ endif
 CORE_SERVICES := dns certgetter ca ingress ingress_prom_exporter vault
 BACKUP := registry_backup
 REGISTRY := registry registryui registry_mirror
-MONITORING := grafana prometheus nagios nagios_mysql prometheusblackbox
+MONITORING := grafana prometheus nagios nagios_mysql prometheusblackbox homer
 ELASTIC := es01 es02 es03 kib01 logstash
 PROXY := squidproxy squidmetrics
 MISC := youtube_dl scratch diagrams.net vscode calibre

--- a/ImageRegistry/config/config.example
+++ b/ImageRegistry/config/config.example
@@ -26,6 +26,7 @@
 		{"Name":"scratch","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7125"},
 		{"Name":"diagrams","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7124"},
 		{"Name":"vscode","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7126"},
-		{"Name":"calibre","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7123"}
+		{"Name":"calibre","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7123"},
+		{"Name":"homer","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"8080"},
     ]
 }

--- a/ImageRegistry/docker-compose.monitoring.yml
+++ b/ImageRegistry/docker-compose.monitoring.yml
@@ -74,6 +74,13 @@ services:
       - MYSQL_RANDOM_ROOT_PASSWORD=yes
     volumes:
       - ./mountPoints/nagios/db:/var/lib/mysql
+  homer:
+    image: b4bz/homer:21.03.2
+    volumes:
+      - ./mountPoints/homer/assets/:/www/assets
+    environment:
+      - UID=1000
+      - GID=1000
 volumes:
   registry_data:
   registry_certs:

--- a/ImageRegistry/docker-compose.yml
+++ b/ImageRegistry/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - transmission_temp_certs:/mnt/transmission_temp_certs:rw
       - transmission_persist_certs:/mnt/transmission_persist_certs:rw
       - vault_certs:/mnt/vault_certs:rw
+      - homer_certs:/mnt/homer_certs:rw
     # Tried real hard to run this script with parameters, specifically the array of PSObjects. I could shell in and run the command below just fine, but could not get it in a place for the entrypoint
     # pwsh -command "& /work/New-CFSSL_Certificate.ps1 -certRequests ([PSCustomObject]@{name = 'registry'; hosts = @('ImageRegistry','localhost','127.0.0.1')},[PSCustomObject]@{name = 'grafana'; hosts = @('grafana','localhost','127.0.0.1')})"
     entrypoint: ["pwsh", "/work/New-CFSSL_Certificate.ps1"]
@@ -97,6 +98,7 @@ services:
       - transmission_temp_certs:/etc/nginx/conf.d/transmission_temp:ro
       - transmission_persist_certs:/etc/nginx/conf.d/transmission_persist:ro
       - vault_certs:/etc/nginx/conf.d/vault:ro
+      - homer_certs:/etc/nginx/conf.d/homer:ro
     restart: ${RESTART_POLICY}
   ingress_prom_exporter:
     image: nginx/nginx-prometheus-exporter:0.9.0
@@ -142,3 +144,4 @@ volumes:
   transmission_temp_certs:
   transmission_persist_certs:
   vault_certs:
+  homer_certs:

--- a/ImageRegistry/src/ca/New-CFSSL_Certificate.ps1
+++ b/ImageRegistry/src/ca/New-CFSSL_Certificate.ps1
@@ -21,6 +21,7 @@ param(
 		,[PSCustomObject]@{name = 'transmission_temp'; hosts = @('transmission_temp');}
 		,[PSCustomObject]@{name = 'transmission_persist'; hosts = @('transmission_persist');}
 		,[PSCustomObject]@{name = 'vault'; hosts = @('vault');}
+		,[PSCustomObject]@{name = 'homer'; hosts = @('homer');}
 	),
 	$Country = "US",
 	$State = "Colorado",


### PR DESCRIPTION
…son file. You need to manually tweak the homer config.yml to fix the services property to match the config.yml.dist format. When we generate the YAML it does not convert the array of services quite right yet.

Because of the manual step (and you would probably want to customize icons/messaging) there is a switch on Configure.ps1 to generate it. This lets you generate it once, and then manually update/manage changes after the initial setup.