### PR TITLE
Make it easier to generate TLS certificates for the nginx ingress proxy

### DIFF
--- a/ImageRegistry/BuildTools/setup.certgetter.ps1
+++ b/ImageRegistry/BuildTools/setup.certgetter.ps1
@@ -2,5 +2,8 @@ param(
 	$config
 	,$domain
 	)
-$config.Records | Select hosts,name,uid,gid,signingProfile
-$out | ConvertTo-Json -depth 5 | set-content $PSScriptRoot\test.json
+Write-Log "Configureing the certgetter"
+$out = $config.Records | Select hosts,name,uid,gid,signingProfile
+$data = $out | ConvertTo-Json -depth 5 
+
+set-content -Value $data -Path "$(Split-Path $PSScriptRoot -Parent)\mountPoints\certgetter\certrequests.json"

--- a/ImageRegistry/BuildTools/setup.ingress.ps1
+++ b/ImageRegistry/BuildTools/setup.ingress.ps1
@@ -90,8 +90,8 @@ foreach($record in $config.Records){
 		$outConfig += "
 $SnippetHttpToHttpsRedirect
 server {
-	ssl_certificate /etc/nginx/conf.d/$($record.Name)/cert.crt;
-	 ssl_certificate_key /etc/nginx/conf.d/$($record.Name)/cert.key;
+	ssl_certificate /etc/nginx/conf.d/certs/$($record.Name)/cert.crt;
+	 ssl_certificate_key /etc/nginx/conf.d/certs/$($record.Name)/cert.key;
 	ssl_session_timeout  5m;
 	ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
 	ssl_ciphers          ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+EXP;
@@ -136,8 +136,8 @@ $SnippetHttpToHttpsRedirect
 server {
 	auth_basic           `"Administrator's Area`";
 	auth_basic_user_file /etc/nginx/basicAuth/$($record.Name).htpasswd;
-	ssl_certificate /etc/nginx/conf.d/$($record.Name)/cert.crt;
-	 ssl_certificate_key /etc/nginx/conf.d/$($record.Name)/cert.key;
+	ssl_certificate /etc/nginx/conf.d/certs/$($record.Name)/cert.crt;
+	 ssl_certificate_key /etc/nginx/conf.d/certs/$($record.Name)/cert.key;
 	ssl_session_timeout  5m;
 	ssl_protocols        TLSv1 TLSv1.1 TLSv1.2;
 	ssl_ciphers          ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+EXP;

--- a/ImageRegistry/Makefile
+++ b/ImageRegistry/Makefile
@@ -8,7 +8,7 @@ endif
 CORE_SERVICES := ${NOOP} dns certgetter ca ingress ingress_prom_exporter vault
 BACKUP := ${NOOP} registry_backup
 REGISTRY := ${NOOP} registry registryui registry_mirror
-MONITORING := ${NOOP} grafana prometheus nagios nagios_mysql prometheusblackbox homer influxdb alertmanager pushgateway
+MONITORING := ${NOOP} grafana prometheus nagios nagios_mysql prometheusblackbox homer alertmanager pushgateway
 ELASTIC := ${NOOP} es01 es02 es03 kib01 logstash
 PROXY := ${NOOP} squidproxy squidmetrics
 MISC := ${NOOP} youtube_dl scratch diagrams.net vscode calibre
@@ -29,7 +29,7 @@ classpathify = $(subst $(eval) ,:,$($1))
 
 SWARM_FILE_JOINED_SYNTAX = $(subst $(eval) , -c .\,$1)
 SWARM_SERVICES_JOINED_SYNTAX = $(subst $(eval) , $1,$2)
-COMPOSE_FILE_JOINED_SYNTAX = $(subst $(eval) , -f ,${COMPOSE_ALL_FILES})
+COMPOSE_FILE_JOINED_SYNTAX = $(subst $(eval) , -f ,$1)
 # --------------------------
 
 
@@ -54,10 +54,12 @@ registry: core
 
 core:
 	@docker-compose ${call COMPOSE_FILE_JOINED_SYNTAX,${CORE_SERVICES_FILES}} up -d --build ${CORE_SERVICES}
+
 elastic:
 	@docker-compose ${call COMPOSE_FILE_JOINED_SYNTAX,${COMPOSE_ELASTIC_FILES}} up -d --build ${ELASTIC}
+
 misc:
-	@docker-compose ${call COMPOSE_FILE_JOINED_SYNTAX,${COMPOSE_MISC_FILES}} up -d --build ${MISC_SERVICES}
+	docker-compose ${call COMPOSE_FILE_JOINED_SYNTAX,${COMPOSE_MISC_FILES}} up -d --build ${MISC_SERVICES}
 
 down:		
 	@docker-compose ${call COMPOSE_FILE_JOINED_SYNTAX,${COMPOSE_ALL_FILES}} down

--- a/ImageRegistry/config/config.example
+++ b/ImageRegistry/config/config.example
@@ -30,5 +30,6 @@
 		{"Name":"vscode","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7126"},
 		{"Name":"calibre","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"7123"},
 		{"Name":"homer","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"8080"},
+		{"Name":"barcodegenerator","ZoneClass":"IN","RecordType":"A","IpAddress":"localhost","port":"3000"}
     ]
 }

--- a/ImageRegistry/docker-compose.misc.yml
+++ b/ImageRegistry/docker-compose.misc.yml
@@ -11,8 +11,9 @@ services:
     image: "leejoneshane/docker-scratch3"
     container_name: scratch3
     restart: always
-    ports:
-      - 7125:80 
+  barcodegenerator:
+    image: "padiazg/barcode-generator"
+    restart: always
   vscode:
     image: ghcr.io/linuxserver/code-server
     env_file: vscode.env

--- a/ImageRegistry/docker-compose.monitoring.yml
+++ b/ImageRegistry/docker-compose.monitoring.yml
@@ -19,7 +19,6 @@ services:
       - ./mountPoints/grafana/grafana.ini:/etc/grafana/grafana.ini
       - grafana_home:/usr/share/grafana
       - grafana_logs:/var/log/grafana
-      - grafana_certs:/mnt/certs
     restart: ${RESTART_POLICY}
   prometheus:
     depends_on:

--- a/ImageRegistry/docker-compose.yml
+++ b/ImageRegistry/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       dockerfile: Dockerfile
     restart: ${RESTART_POLICY}
     volumes:
+      - ./mountPoints/certgetter/certrequests.json:/mnt/certrequests.json:ro
       - registry_certs:/mnt/registry_certs:rw
       - grafana_certs:/mnt/grafana_certs:rw
       - ca_certs:/mnt/ca_certs:rw

--- a/ImageRegistry/docker-compose.yml
+++ b/ImageRegistry/docker-compose.yml
@@ -29,31 +29,7 @@ services:
     restart: ${RESTART_POLICY}
     volumes:
       - ./mountPoints/certgetter/certrequests.json:/mnt/certrequests.json:ro
-      - registry_certs:/mnt/registry_certs:rw
-      - grafana_certs:/mnt/grafana_certs:rw
-      - ca_certs:/mnt/ca_certs:rw
-      - registryui_certs:/mnt/registryui_certs:rw
-      - registry_mirror_certs:/mnt/registry_mirror_certs:rw
-      - squid_certs:/mnt/squid_certs:rw
-      - ldap_certs:/mnt/ldap_certs:rw
-      - nextcloud_certs:/mnt/nextcloud_certs:rw
-      - kibana_certs:/mnt/kibana_certs:rw
-      - elastic_certs:/mnt/elastic_certs:rw
-      - diagrams_certs:/mnt/diagrams_certs:rw
-      - nagios_certs:/mnt/nagios_certs:rw
-      - prometheus_certs:/mnt/prometheus_certs:rw
-      - prometheusblackbox_certs:/mnt/prometheusblackbox_certs:rw
-      - vscode_certs:/mnt/vscode_certs:rw
-      - calibre_certs:/mnt/calibre_certs:rw
-      - mineos_certs:/mnt/mineos_certs:rw
-      - scratch_certs:/mnt/scratch_certs:rw
-      - ingress_certs:/mnt/ingress_certs:rw
-      - transmission_temp_certs:/mnt/transmission_temp_certs:rw
-      - transmission_persist_certs:/mnt/transmission_persist_certs:rw
-      - vault_certs:/mnt/vault_certs:rw
-      - homer_certs:/mnt/homer_certs:rw
-      - alertmanager_certs:/mnt/alertmanager_certs:rw
-      - pushgateway_certs:/mnt/pushgateway_certs:rw
+      - cfssl_certs:/mnt/cfssl_certs:rw
     # Tried real hard to run this script with parameters, specifically the array of PSObjects. I could shell in and run the command below just fine, but could not get it in a place for the entrypoint
     # pwsh -command "& /work/New-CFSSL_Certificate.ps1 -certRequests ([PSCustomObject]@{name = 'registry'; hosts = @('ImageRegistry','localhost','127.0.0.1')},[PSCustomObject]@{name = 'grafana'; hosts = @('grafana','localhost','127.0.0.1')})"
     entrypoint: ["pwsh", "/work/New-CFSSL_Certificate.ps1"]
@@ -82,30 +58,7 @@ services:
     volumes:
       - ./mountPoints/ingress/basicAuth:/etc/nginx/basicAuth
       - ./mountPoints/ingress/nginx.conf:/etc/nginx/nginx.conf
-      - ca_certs:/etc/nginx/conf.d/ca:ro
-      - grafana_certs:/etc/nginx/conf.d/grafana:ro
-      - ldap_certs:/etc/nginx/conf.d/ldap:ro
-      - nextcloud_certs:/etc/nginx/conf.d/nextcloud:ro
-      - kibana_certs:/etc/nginx/conf.d/kibana:ro
-      - elastic_certs:/etc/nginx/conf.d/elastic:ro
-      - diagrams_certs:/etc/nginx/conf.d/diagrams:ro
-      - nagios_certs:/etc/nginx/conf.d/nagios:ro
-      - prometheus_certs:/etc/nginx/conf.d/prometheus:ro
-      - prometheusblackbox_certs:/etc/nginx/conf.d/prometheusblackbox:ro
-      - registryui_certs:/etc/nginx/conf.d/registryui:ro
-      - registry_certs:/etc/nginx/conf.d/registry:ro
-      - registry_mirror_certs:/etc/nginx/conf.d/registry_mirror:ro
-      - vscode_certs:/etc/nginx/conf.d/vscode:ro
-      - calibre_certs:/etc/nginx/conf.d/calibre:ro
-      - mineos_certs:/etc/nginx/conf.d/mineos:ro
-      - scratch_certs:/etc/nginx/conf.d/scratch:ro
-      - ingress_certs:/etc/nginx/conf.d/ingress:ro
-      - transmission_temp_certs:/etc/nginx/conf.d/transmission_temp:ro
-      - transmission_persist_certs:/etc/nginx/conf.d/transmission_persist:ro
-      - vault_certs:/etc/nginx/conf.d/vault:ro
-      - homer_certs:/etc/nginx/conf.d/homer:ro
-      - alertmanager_certs:/etc/nginx/conf.d/alertmanager:ro
-      - pushgateway_certs:/etc/nginx/conf.d/pushgateway:ro
+      - cfssl_certs:/etc/nginx/conf.d/certs:ro
     restart: ${RESTART_POLICY}
   ingress_prom_exporter:
     image: nginx/nginx-prometheus-exporter:0.9.0
@@ -122,8 +75,7 @@ services:
       entrypoint: vault server -config=/vault/config/vault.json
       restart: ${RESTART_POLICY}
 volumes:
-  registry_certs:
-  registry_requested_certs:
+  cfssl_certs:
   registry_auth:
   grafana_data:
   grafana_plugins:
@@ -133,27 +85,4 @@ volumes:
   grafana_certs:
   squid_cache:
   squid_log:
-  squid_certs:
-  ca_certs:
-  registryui_certs:
-  registry_mirror_certs:
-  ldap_certs:
   dhcp_leases:
-  nextcloud_certs:
-  elastic_certs:
-  kibana_certs:
-  diagrams_certs:
-  nagios_certs:
-  prometheus_certs:
-  prometheusblackbox_certs:
-  vscode_certs:
-  calibre_certs:
-  mineos_certs:
-  scratch_certs:
-  ingress_certs:  
-  transmission_temp_certs:
-  transmission_persist_certs:
-  vault_certs:
-  homer_certs:
-  alertmanager_certs:
-  pushgateway_certs:

--- a/ImageRegistry/mountPoints/certgetter/certrequests.json.example
+++ b/ImageRegistry/mountPoints/certgetter/certrequests.json.example
@@ -1,0 +1,150 @@
+[
+  {
+    "name": "registry",
+    "hosts": [
+      "ImageRegistry"
+    ]
+  },
+  {
+    "name": "grafana",
+    "hosts": [
+      "grafana"
+    ]
+  },
+  {
+    "name": "squid",
+    "hosts": [
+      "proxy"
+    ],
+    "uid": "200",
+    "gid": "200",
+    "signingProfile": "any"
+  },
+  {
+    "name": "registryui",
+    "hosts": [
+      "ImageRegistry",
+      "registry"
+    ]
+  },
+  {
+    "name": "registry_mirror",
+    "hosts": [
+      "registry_mirror"
+    ]
+  },
+  {
+    "name": "ca",
+    "hosts": [
+      "ca"
+    ]
+  },
+  {
+    "name": "nextcloud",
+    "hosts": [
+      "nc"
+    ]
+  },
+  {
+    "name": "elastic",
+    "hosts": [
+      "elastic"
+    ]
+  },
+  {
+    "name": "kibana",
+    "hosts": [
+      "kibana"
+    ]
+  },
+  {
+    "name": "diagrams",
+    "hosts": [
+      "diagrams"
+    ]
+  },
+  {
+    "name": "nagios",
+    "hosts": [
+      "nagios"
+    ]
+  },
+  {
+    "name": "prometheus",
+    "hosts": [
+      "prometheus"
+    ]
+  },
+  {
+    "name": "vscode",
+    "hosts": [
+      "vscode"
+    ]
+  },
+  {
+    "name": "calibre",
+    "hosts": [
+      "calibre"
+    ]
+  },
+  {
+    "name": "mineos",
+    "hosts": [
+      "mineos"
+    ]
+  },
+  {
+    "name": "scratch",
+    "hosts": [
+      "scratch"
+    ]
+  },
+  {
+    "name": "prometheusblackbox",
+    "hosts": [
+      "prometheusblackbox"
+    ]
+  },
+  {
+    "name": "ingress",
+    "hosts": [
+      "ingress"
+    ]
+  },
+  {
+    "name": "transmission_temp",
+    "hosts": [
+      "transmission_temp"
+    ]
+  },
+  {
+    "name": "transmission_persist",
+    "hosts": [
+      "transmission_persist"
+    ]
+  },
+  {
+    "name": "vault",
+    "hosts": [
+      "vault"
+    ]
+  },
+  {
+    "name": "homer",
+    "hosts": [
+      "homer"
+    ]
+  },
+  {
+    "name": "alertmanager",
+    "hosts": [
+      "alertmanager"
+    ]
+  },
+  {
+    "name": "pushgateway",
+    "hosts": [
+      "pushgateway"
+    ]
+  }
+]

--- a/ImageRegistry/mountPoints/grafana/grafana.ini
+++ b/ImageRegistry/mountPoints/grafana/grafana.ini
@@ -19,7 +19,7 @@
 #################################### Server ####################################
 [server]
 # Protocol (http or https)
-protocol = https
+protocol = http
 
 # The ip address to bind to, empty will bind to all interfaces
 #http_addr = 127.0.0.1
@@ -46,9 +46,6 @@ protocol = https
 # enable gzip
 ;enable_gzip = false
 
-# https certs & key file
-cert_file = /mnt/certs/cert.crt
-cert_key = /mnt/certs/cert.key
 
 #################################### Database ####################################
 [database]

--- a/ImageRegistry/src/ca/New-CFSSL_Certificate.ps1
+++ b/ImageRegistry/src/ca/New-CFSSL_Certificate.ps1
@@ -7,7 +7,7 @@ param(
 	$caURL = 'http://ca:8888',
 	$ca_basicaauth_Username = '',
 	$ca_basicaauth_Password = '',
-	$certOutPath = '/mnt',
+	$certOutPath = '/mnt/cfssl_certs',
 	$domainName = '.mcd.com' # Will be suffixed onto each host
 )
 $certRequests = Get-Content $certRequestsPath | ConvertFrom-Json
@@ -106,14 +106,17 @@ foreach ($request in $certRequests){
 	$result.result.certificate | Out-File cert.crt
 
 	Get-ChildItem /work
-	Copy-Item -Path /work/cert.crt -Destination $certOutPath/$($request.name)_certs/cert.crt
-	Copy-Item -Path /work/cert.key -Destination $certOutPath/$($request.name)_certs/cert.key 
+	if (-not (Test-Path "$certOutPath/$($request.name)/")){
+		New-Item -Path "$certOutPath/$($request.name)/" -ItemType Directory -force
+	}
+	Copy-Item -Path /work/cert.crt -Destination $certOutPath/$($request.name)/cert.crt
+	Copy-Item -Path /work/cert.key -Destination $certOutPath/$($request.name)/cert.key 
 
 	if (-not [string]::IsNullOrEmpty($request.uid) -and -not [string]::IsNullOrEmpty($request.gid)){
 		Write-Host "Setting the UID:GID ownership"
-		chown $($request.uid):$($request.gid) $certOutPath/$($request.name)_certs/cert.crt
+		chown $($request.uid):$($request.gid) $certOutPath/$($request.name)/cert.crt
 		chmod 444 $certOutPath/$($request.name)_certs/cert.crt
-		chown $($request.uid):$($request.gid) $certOutPath/$($request.name)_certs/cert.key
+		chown $($request.uid):$($request.gid) $certOutPath/$($request.name)/cert.key
 		chmod 444 $certOutPath/$($request.name)_certs/cert.key
 	}
 }

--- a/ImageRegistry/src/ca/New-CFSSL_Certificate.ps1
+++ b/ImageRegistry/src/ca/New-CFSSL_Certificate.ps1
@@ -1,31 +1,6 @@
 param(
 	$dev_bindings = $true,
-	$certRequests = @(
-		[PSCustomObject]@{name = 'registry'; hosts = @('ImageRegistry')}
-		,[PSCustomObject]@{name = 'grafana'; hosts = @('grafana')}
-		,[PSCustomObject]@{name = 'squid'; hosts = @('proxy'); uid = '200'; gid = '200'; signingProfile = "any"}
-		,[PSCustomObject]@{name = 'registryui'; hosts = @('ImageRegistry','registry');}
-		,[PSCustomObject]@{name = 'registry_mirror'; hosts = @('registry_mirror');}
-		,[PSCustomObject]@{name = 'ca'; hosts = @('ca');}
-		,[PSCustomObject]@{name = 'nextcloud'; hosts = @('nc');}
-		,[PSCustomObject]@{name = 'elastic'; hosts = @('elastic');}
-		,[PSCustomObject]@{name = 'kibana'; hosts = @('kibana');}
-		,[PSCustomObject]@{name = 'diagrams'; hosts = @('diagrams');}
-		,[PSCustomObject]@{name = 'nagios'; hosts = @('nagios');}
-		,[PSCustomObject]@{name = 'prometheus'; hosts = @('prometheus');}
-		,[PSCustomObject]@{name = 'vscode'; hosts = @('vscode');}
-		,[PSCustomObject]@{name = 'calibre'; hosts = @('calibre');}
-		,[PSCustomObject]@{name = 'mineos'; hosts = @('mineos');}
-		,[PSCustomObject]@{name = 'scratch'; hosts = @('scratch');}
-		,[PSCustomObject]@{name = 'prometheusblackbox'; hosts = @('prometheusblackbox');}
-		,[PSCustomObject]@{name = 'ingress'; hosts = @('ingress');}
-		,[PSCustomObject]@{name = 'transmission_temp'; hosts = @('transmission_temp');}
-		,[PSCustomObject]@{name = 'transmission_persist'; hosts = @('transmission_persist');}
-		,[PSCustomObject]@{name = 'vault'; hosts = @('vault');}
-		,[PSCustomObject]@{name = 'homer'; hosts = @('homer');}
-		[PSCustomObject]@{name = 'alertmanager'; hosts = @('alertmanager');}
-		[PSCustomObject]@{name = 'pushgateway'; hosts = @('pushgateway');}
-	),
+	$certRequestsPath = "/mnt/certrequests.json",
 	$Country = "US",
 	$State = "Colorado",
 	$Location = "Denver",
@@ -35,6 +10,7 @@ param(
 	$certOutPath = '/mnt',
 	$domainName = '.mcd.com' # Will be suffixed onto each host
 )
+$certRequests = Get-Content $certRequestsPath | ConvertFrom-Json
 $newRequests =@()
 foreach($certRequestIndex in 0..$(($certRequests | measure-object | select -ExpandProperty Count)-1)){
 	if([string]::IsNullOrEmpty($certRequestIndex.signingProfile)){


### PR DESCRIPTION
generate the certgetter/certrequests.json file from the config.json and the New-CFSSL_Certificate.ps1will read this json file instead of needed to be hardcoded with the hosts we want to generate certs for